### PR TITLE
Use high accuracy transform for BNG tilesource

### DIFF
--- a/MaplyAdapter/OSBNGUtils.m
+++ b/MaplyAdapter/OSBNGUtils.m
@@ -13,7 +13,7 @@
 @implementation OSBNGUtils
 
 + (MaplyProj4CoordSystem *)bngCoordinateSystem {
-    NSString *proj4Str = [OSBNGTransformation sevenParamProj4String];
+    NSString *proj4Str = [OSBNGTransformation proj4String];
     MaplyProj4CoordSystem *coordSys = [[MaplyProj4CoordSystem alloc] initWithString:proj4Str];
     return coordSys;
 }

--- a/MaplyExampleObjC/ViewController.m
+++ b/MaplyExampleObjC/ViewController.m
@@ -25,7 +25,7 @@
     // Create map and tile layer
     self.maplyViewController = [self createMaplyViewController];
     [self addMapToViewHierarchy];
-    MaplyQuadImageTilesLayer *tileLayer = [OSTileSourceFactory create3857TileLayer];
+    MaplyQuadImageTilesLayer *tileLayer = [OSTileSourceFactory create27700TileLayer];
     [self.maplyViewController addLayer:tileLayer];
 
     // Create test marker
@@ -54,6 +54,7 @@
     maplyViewController.doubleTapZoomGesture = true;
     maplyViewController.twoFingerTapGesture = true;
     maplyViewController.cancelAnimationOnTouch = true;
+    maplyViewController.coordSys = [OSBNGUtils buildBritishNationalGrid];
     maplyViewController.delegate = self;
     return maplyViewController;
 }


### PR DESCRIPTION
For reasons that aren't immediately obvious, it appears that the version of
proj.4 in use in Maply 4.3.1_beta3 has some trouble with BNG tile sources using
the 7 param transformation, resulting in a blank map.

Switching to the OSTN02 transformation when creating the coordinate
system fixes this. Further investigation is required to determine the root
cause.
